### PR TITLE
Adapt MPE to work better with different devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Paper: https://arxiv.org/abs/2310.19273
 
 - To create a conda environment `mpe` with all necessary dependencies run: `conda env create --file environment.yml`
 - We use torch 2.2.1 with cuda 12.1.1
+- The current environment.yml file limits python to be lower than version 3.13
 
 **Additional information on dependencies**
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Paper: https://arxiv.org/abs/2310.19273
 ## Installation
 
 - To create a conda environment `mpe` with all necessary dependencies run: `conda env create --file environment.yml`
-- Additionally, run `pip install git+https://git@github.com/wiseodd/asdl@asdfghjkl` in the mpe environment to gain access to `asdfghjkl` backend and `AsdlGGN`
 - We use torch 2.2.1 with cuda 12.1.1
 
 **Additional information on dependencies**

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Paper: https://arxiv.org/abs/2310.19273
 ## Installation
 
 - To create a conda environment `mpe` with all necessary dependencies run: `conda env create --file environment.yml`
+- Additionally, run `pip install git+https://git@github.com/wiseodd/asdl@asdfghjkl` in the mpe environment to gain access to `asdfghjkl` backend and `AsdlGGN`
 - We use torch 2.2.1 with cuda 12.1.1
 
 **Additional information on dependencies**

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - pytorch
   - nvidia
 dependencies:
-  - python ==3.12
+  - python < 3.13
   - matplotlib
   - scikit-learn
   - tqdm

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - pytorch
   - nvidia
 dependencies:
+  - python ==3.12
   - matplotlib
   - scikit-learn
   - tqdm

--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,4 @@ dependencies:
     - torchaudio
     - ivon-opt==0.1
     - laplace-torch==0.1a2
+    - git+https://git@github.com/wiseodd/asdl@asdfghjkl

--- a/examples/1_loo_iterations.py
+++ b/examples/1_loo_iterations.py
@@ -113,9 +113,9 @@ def get_prediction_vars(optim, device):
 
     else:  # Laplace variance approximation
         if args.var_version == 'kfac':
-            vars = get_pred_vars_laplace(net, trainloader_vars, args.delta, nc, version='kfac')
+            vars = get_pred_vars_laplace(net, trainloader_vars, args.delta, nc, device, version='kfac')
         elif args.var_version == 'diag':
-            vars = get_pred_vars_laplace(net, trainloader_vars, args.delta, nc, version='diag')
+            vars = get_pred_vars_laplace(net, trainloader_vars, args.delta, nc, device, version='diag')
         else:
             raise NotImplementedError
 

--- a/examples/2_loo_l2reg.py
+++ b/examples/2_loo_l2reg.py
@@ -85,6 +85,7 @@ if __name__ == "__main__":
     np.random.seed(seed)
     torch.manual_seed(seed)
 
+    # Device, get_pred_vars_laplace only works with cuda or cpu
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     print('device', device)
 
@@ -99,7 +100,7 @@ if __name__ == "__main__":
     tr_targets, te_targets = torch.asarray(ds_train.targets), torch.asarray(ds_test.targets)
 
     # Dataloaders
-    trainloader = get_quick_loader(DataLoader(ds_train, batch_size=args.bs)) # training
+    trainloader = get_quick_loader(DataLoader(ds_train, batch_size=args.bs), device=device) # training
     trainloader_eval = DataLoader(ds_train, batch_size=args.bs, shuffle=False) # train evaluation
     testloader_eval = DataLoader(ds_test, batch_size=args.bs, shuffle=False) # test evaluation
     trainloader_vars = DataLoader(ds_train, batch_size=args.bs_jacs, shuffle=False) # variance computation
@@ -128,7 +129,7 @@ if __name__ == "__main__":
         print(f"Train Acc: {(100 * train_acc):>0.2f}%, Train NLL: {train_nll:>6f}")
 
         # Compute predictive Laplace variances
-        vars_c = get_pred_vars_laplace(net, trainloader_vars, delta, nc, 'kfac', device=device)
+        vars_c = get_pred_vars_laplace(net, trainloader_vars, delta, nc, device, 'kfac')
         vars_list.append(vars_c)
 
     residuals_list, vars_list, logits_list = np.asarray(residuals_list), np.asarray(vars_list), np.asarray(logits_list)
@@ -147,5 +148,3 @@ if __name__ == "__main__":
     os.makedirs(os.path.dirname(dir), exist_ok=True)
     with open(dir + args.name_exp + '_cv.pkl', 'wb') as f:
         pickle.dump(results_dict, f, pickle.HIGHEST_PROTOCOL)
-
-

--- a/examples/3_validation_sensitivities.py
+++ b/examples/3_validation_sensitivities.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     print(f"Test Acc: {(100 * test_acc):>0.2f}%, Test NLL: {test_nll:>6f}")
 
     # Compute prediction variances
-    vars = get_pred_vars_laplace(net, trainloader_vars, args.delta, nc, version='kfac', device=device)
+    vars = get_pred_vars_laplace(net, trainloader_vars, args.delta, nc, device, version='kfac')
 
     # Compute and store sensitivities
     sensitivities = np.asarray(residuals) * np.asarray(lambdas) * np.asarray(vars)

--- a/examples/4_evolving_sensitivities.py
+++ b/examples/4_evolving_sensitivities.py
@@ -76,7 +76,9 @@ if __name__ == "__main__":
         evaluate_iterations = [10, 2000, 10000, 24500]
     else:
         raise NotImplementedError
-    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    
+    # Device
+    device = 'mps' if torch.backends.mps.is_available() else 'cuda' if torch.cuda.is_available() else 'cpu'
     print('device', device)
 
     # Loss
@@ -90,7 +92,7 @@ if __name__ == "__main__":
     tr_targets, te_targets = torch.asarray(ds_train.targets), torch.asarray(ds_test.targets)
 
     # Dataloaders
-    trainloader = get_quick_loader(DataLoader(ds_train, batch_size=args.bs)) # training
+    trainloader = get_quick_loader(DataLoader(ds_train, batch_size=args.bs), device=device) # training
     trainloader_eval = DataLoader(ds_train, batch_size=args.bs, shuffle=False) # train evaluation
     testloader_eval = DataLoader(ds_test, batch_size=args.bs, shuffle=False) # test evaluation
     trainloader_vars = DataLoader(ds_train, batch_size=args.bs_jacs, shuffle=False) # variance computation

--- a/examples/5_loco.py
+++ b/examples/5_loco.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     print(f"Test Acc: {(100 * test_acc):>0.2f}%, Test NLL: {test_nll:>6f}")
 
     # Compute prediction variances
-    vars = get_pred_vars_laplace(net, trainloader_vars, args.delta, nc, version='kfac', device=device)
+    vars = get_pred_vars_laplace(net, trainloader_vars, args.delta, nc, device, version='kfac')
 
     residuals, vars, tr_logits = np.asarray(residuals), np.asarray(vars), np.asarray(tr_logits)
 

--- a/lib/variances.py
+++ b/lib/variances.py
@@ -19,7 +19,7 @@ def get_pred_vars_laplace(net, trainloader, delta, nc, device='cuda', version='k
         prior_precision=delta,
         backend=AsdlGGN)
 
-    if torch.cuda.is_available():
+    if device == 'cuda':
         torch.cuda.empty_cache()
 
     laplace_object.fit(trainloader)
@@ -31,7 +31,7 @@ def get_pred_vars_laplace(net, trainloader, delta, nc, device='cuda', version='k
         fvars = np.vstack((fvars, np.diagonal(fvar.cpu().numpy(), axis1=1, axis2=2)))
 
     del laplace_object
-    if torch.cuda.is_available():
+    if device == 'cuda':
         torch.cuda.empty_cache()
 
     return fvars.tolist()


### PR DESCRIPTION
Experiment 1 (only when using `--optim_var`) and 4 can now run on MPS device built for M-series Mac.

Variance prediction that utilize laplace on 1, 2,3 and 5 cannot run on MPS due to current pytorch implementation limitation related to aten::im2col not being supported on MPS. This current implementation forces experiments needing laplace package to run on CPU if running on a M-series device.

This pull request also address python version issue. Currently on version 3.13, torchvision is not supported on stable channel and is available on nightly only. To overcome this the env yml had to limit python version for the time being.

The env file is now added with pip install of asdfghjkl backend to properly address usage of laplace package.

Clarification about the python version added to env yml is added on readme.